### PR TITLE
Fix cross-platform inconsistency in path slashes 

### DIFF
--- a/wow_message_parser/Cargo.toml
+++ b/wow_message_parser/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 pest = "2.0"
 pest_derive = "2.0"
 walkdir = "2.3.2"
+path-slash = "0.2.1"
 heck = "0.3.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/wow_message_parser/src/parser/mod.rs
+++ b/wow_message_parser/src/parser/mod.rs
@@ -93,7 +93,10 @@ pub fn parse_file(filename: &Path) -> Objects {
         .expect("unable to find statements")
         .into_inner();
 
-    parse_statements(&mut statements, commands.tags(), filename.to_str().unwrap())
+    use path_slash::PathExt as _;
+    let filename = filename.to_slash().unwrap();
+
+    parse_statements(&mut statements, commands.tags(), &filename)
 }
 
 fn parse_statements(statements: &mut Pairs<Rule>, tags: &Tags, filename: &str) -> Objects {


### PR DESCRIPTION
Fix cross-platform inconsistency in path slashes that causes every single file to be changed on Windows when running the parser, even though nothing really changed in the source wowm files. This PR makes the paths always printed as forward slashes regardless of platform.