### PR TITLE
[WIP] Put common enums in their own module.

### DIFF
--- a/wow_message_parser/Cargo.toml
+++ b/wow_message_parser/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 pest = "2.0"
 pest_derive = "2.0"
 walkdir = "2.3.2"
+path-slash = "0.2.1"
 heck = "0.3.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/wow_message_parser/src/container.rs
+++ b/wow_message_parser/src/container.rs
@@ -274,9 +274,9 @@ impl Container {
         let import_path = if self.tags().logon_versions().contains(&LoginVersion::All) {
             let mut tags = Tags::new();
             tags.push(Tag::new(LOGIN_VERSIONS, "3"));
-            get_import_path(&tags)
+            get_import_path(&tags, None)
         } else {
-            get_import_path(self.tags())
+            get_import_path(self.tags(), None)
         };
         match self.container_type() {
             ContainerType::CLogin(_) => {

--- a/wow_message_parser/src/doc_printer/mod.rs
+++ b/wow_message_parser/src/doc_printer/mod.rs
@@ -82,7 +82,7 @@ fn create_or_append_hashmap(s: &str, path: String, files: &mut HashMap<String, S
 }
 
 pub fn print_docs_summary_and_objects(definers: &[DocWriter], containers: &[DocWriter]) {
-    const LOGIN_DEFINER_HEADER: &str = "# Login Definers\n";
+    const LOGIN_DEFINER_HEADER: &str = "# Login Definers";
     const LOGIN_CONTAINER_HEADER: &str = "# Login Containers\n";
     const WORLD_DEFINER_HEADER: &str = "# World Definers\n";
     const WORLD_CONTAINER_HEADER: &str = "# Login Containers\n";

--- a/wow_message_parser/src/file_utils.rs
+++ b/wow_message_parser/src/file_utils.rs
@@ -57,13 +57,14 @@ impl ModFiles {
                         writeln!(s, "pub use {}::*;", i).unwrap();
                     }
                     SubmoduleLocation::PubMod => {
-                        if ["vanilla", "wrath", "tbc", "shared"].contains(&i.as_str()) {
+                        if ["vanilla", "wrath", "tbc"].contains(&i.as_str()) {
                             writeln!(s, "#[cfg(feature = \"{}\")]", i).unwrap();
                         }
                         writeln!(s, "pub mod {};", i).unwrap();
                     }
                 }
             }
+
             let filename = m.name.to_string() + "mod.rs";
 
             self.already_existing_files.insert(filename.clone(), true);
@@ -131,7 +132,11 @@ impl ModFiles {
             file_dir.clone(),
             (get_module_name(name), SubmoduleLocation::PubUseInternal),
         );
-        self.add_or_append_file(file_dir, ("opcodes".to_string(), SubmoduleLocation::PubMod));
+
+        //Since only enums can end up in Shared, we don't need an opcode mod
+        if major_version_to_string(version) != "shared" {
+            self.add_or_append_file(file_dir, ("opcodes".to_string(), SubmoduleLocation::PubMod));
+        }
     }
 
     pub fn add_login_file(&mut self, name: &str, version: &LoginVersion) {

--- a/wow_message_parser/src/file_utils.rs
+++ b/wow_message_parser/src/file_utils.rs
@@ -57,7 +57,7 @@ impl ModFiles {
                         writeln!(s, "pub use {}::*;", i).unwrap();
                     }
                     SubmoduleLocation::PubMod => {
-                        if ["vanilla", "wrath", "tbc"].contains(&i.as_str()) {
+                        if ["vanilla", "wrath", "tbc", "shared"].contains(&i.as_str()) {
                             writeln!(s, "#[cfg(feature = \"{}\")]", i).unwrap();
                         }
                         writeln!(s, "pub mod {};", i).unwrap();
@@ -106,6 +106,12 @@ impl ModFiles {
         assert!(version.is_main_version());
 
         if tags.is_in_common() {
+            assert!(
+                tags.has_wildcard_world_version(),
+                "Common types can only have a wildcard world version. Type {} has versions {} but is also marked as common.",
+                name,
+                version
+                );
             self.add_or_append_file(
                 format!("{}/", BASE_DIR),
                 (get_module_name(name), SubmoduleLocation::PubUseInternal),
@@ -254,7 +260,8 @@ fn major_version_to_string(v: &WorldVersion) -> &'static str {
 
             version(m)
         }
-        WorldVersion::Exact(_, _, _, _) | WorldVersion::All => unimplemented!(),
+        WorldVersion::All => "shared",
+        WorldVersion::Exact(_, _, _, _) => unimplemented!(),
     }
 }
 

--- a/wow_message_parser/src/file_utils.rs
+++ b/wow_message_parser/src/file_utils.rs
@@ -302,8 +302,10 @@ pub fn get_login_version_file_path(version: &LoginVersion) -> String {
     }
 }
 
-pub fn get_import_path(tags: &Tags) -> String {
-    if let Some(f) = tags.logon_versions().first() {
+pub fn get_import_path(tags: &Tags, preferred_version: Option<&WorldVersion>) -> String {
+    if let Some(target_world_version) = preferred_version {
+        get_world_version_path(target_world_version)
+    } else if let Some(f) = tags.logon_versions().first() {
         get_login_logon_version_path(f)
     } else if let Some(f) = tags.first_major_version() {
         get_world_version_path(f)

--- a/wow_message_parser/src/parser/mod.rs
+++ b/wow_message_parser/src/parser/mod.rs
@@ -93,7 +93,10 @@ pub fn parse_file(filename: &Path) -> Objects {
         .expect("unable to find statements")
         .into_inner();
 
-    parse_statements(&mut statements, commands.tags(), filename.to_str().unwrap())
+    use path_slash::PathExt as _;
+    let filename = filename.to_slash().unwrap();
+
+    parse_statements(&mut statements, commands.tags(), &filename)
 }
 
 fn parse_statements(statements: &mut Pairs<Rule>, tags: &Tags, filename: &str) -> Objects {

--- a/wow_message_parser/src/parser/types/tags.rs
+++ b/wow_message_parser/src/parser/types/tags.rs
@@ -461,7 +461,8 @@ impl TagString {
                 TagStringSymbol::Text(s) => current.push_str(s),
                 TagStringSymbol::Link(s) => {
                     if let Some(tags) = o.get_tags_of_object_fallible(s, object_tags) {
-                        write!(current, "[`{}`]({}::{})", s, get_import_path(tags), s).unwrap()
+                        write!(current, "[`{}`]({}::{})", s, get_import_path(tags, None), s)
+                            .unwrap()
                     } else {
                         write!(current, "`{}`", s).unwrap()
                     }

--- a/wow_message_parser/src/rust_printer/enums.rs
+++ b/wow_message_parser/src/rust_printer/enums.rs
@@ -5,7 +5,7 @@ use crate::wowm_printer::get_definer_wowm_definition;
 use crate::{Objects, DISPLAY_STR};
 
 pub fn print_common_enum_common(e: &Definer, o: &Objects) -> Writer {
-    let mut s = Writer::new(&get_import_path(e.tags()));
+    let mut s = Writer::new(&get_import_path(e.tags(), None));
 
     includes(&mut s);
 
@@ -25,7 +25,7 @@ pub fn print_common_enum_common(e: &Definer, o: &Objects) -> Writer {
 }
 
 pub fn print_common_enum_messages(e: &Definer) -> Writer {
-    let mut s = Writer::new(&get_import_path(e.tags()));
+    let mut s = Writer::new(&get_import_path(e.tags(), None));
 
     s.wln(format!("pub use wow_world_base::{};", e.name()));
     s.newline();
@@ -34,7 +34,7 @@ pub fn print_common_enum_messages(e: &Definer) -> Writer {
 }
 
 pub fn print_enum(e: &Definer, o: &Objects) -> Writer {
-    let mut s = Writer::new(&get_import_path(e.tags()));
+    let mut s = Writer::new(&get_import_path(e.tags(), None));
 
     includes(&mut s);
 

--- a/wow_message_parser/src/rust_printer/flags.rs
+++ b/wow_message_parser/src/rust_printer/flags.rs
@@ -5,7 +5,7 @@ use crate::rust_printer::{print_docc_description_and_comment, Writer};
 use crate::Objects;
 
 pub fn print_flag(e: &Definer, o: &Objects) -> Writer {
-    let mut s = Writer::new(&get_import_path(e.tags()));
+    let mut s = Writer::new(&get_import_path(e.tags(), None));
 
     declaration(&mut s, e, o);
 

--- a/wow_message_parser/src/rust_printer/opcodes.rs
+++ b/wow_message_parser/src/rust_printer/opcodes.rs
@@ -23,7 +23,7 @@ pub fn print_world_opcodes(
         _ => panic!("invalid type passed to opcode printer"),
     };
 
-    includes(&mut s, v, container_type);
+    includes(&mut s, v, Some(version), container_type);
 
     definition(&mut s, v, ty);
 
@@ -44,7 +44,7 @@ pub fn print_login_opcodes(
         _ => panic!("invalid type passed to opcode printer"),
     };
 
-    includes(&mut s, v, container_type);
+    includes(&mut s, v, None, container_type);
 
     definition(&mut s, v, ty);
 
@@ -57,7 +57,12 @@ fn any_container_is_pure_movement_info(v: &[&Container]) -> bool {
     v.iter().any(|a| a.is_pure_movement_info())
 }
 
-pub fn includes(s: &mut Writer, v: &[&Container], container_type: ContainerType) {
+pub fn includes(
+    s: &mut Writer,
+    v: &[&Container],
+    target_world_version: Option<&WorldVersion>,
+    container_type: ContainerType,
+) {
     match container_type {
         ContainerType::SLogin(_) => {
             s.wln(format!(
@@ -87,7 +92,7 @@ pub fn includes(s: &mut Writer, v: &[&Container], container_type: ContainerType)
             if any_container_is_pure_movement_info(v) {
                 s.wln(format!(
                     "use {module_name}::MovementInfo;",
-                    module_name = get_import_path(v.first().unwrap().tags())
+                    module_name = get_import_path(v.first().unwrap().tags(), None)
                 ));
             }
         }
@@ -101,7 +106,7 @@ pub fn includes(s: &mut Writer, v: &[&Container], container_type: ContainerType)
             }
         }
 
-        let module_name = get_import_path(e.tags());
+        let module_name = get_import_path(e.tags(), target_world_version);
         s.wln(format!(
             "use {module_name}::{name};",
             module_name = module_name,

--- a/wow_message_parser/src/rust_printer/structs/mod.rs
+++ b/wow_message_parser/src/rust_printer/structs/mod.rs
@@ -15,7 +15,7 @@ mod print_optional;
 mod print_tests;
 
 pub fn print_struct(e: &Container, o: &Objects) -> Writer {
-    let mut s = Writer::new(&get_import_path(e.tags()));
+    let mut s = Writer::new(&get_import_path(e.tags(), None));
 
     print_includes(&mut s, e, o);
 
@@ -50,7 +50,7 @@ fn print_includes(s: &mut Writer, e: &Container, o: &Objects) {
     }
 
     for name in e.get_types_needing_import() {
-        let module_name = get_import_path(o.get_tags_of_object(name, e.tags()));
+        let module_name = get_import_path(o.get_tags_of_object(name, e.tags()), None);
 
         s.wln(format!(
             "use {module_name}::{name};",

--- a/wow_message_parser/src/rust_printer/structs/print_tests.rs
+++ b/wow_message_parser/src/rust_printer/structs/print_tests.rs
@@ -27,7 +27,7 @@ pub(super) fn print_tests(s: &mut Writer, e: &Container, o: &Objects) {
             let tags = o.get_tags_of_object(name, e.tags());
             s.wln(format!(
                 "use {import_path}::{ty};",
-                import_path = get_import_path(tags),
+                import_path = get_import_path(tags, None),
                 ty = name,
             ));
         }

--- a/wow_message_parser/src/rust_printer/update_mask.rs
+++ b/wow_message_parser/src/rust_printer/update_mask.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 pub fn print_update_mask_docs() {
     const UPDATE_MASK_FILE: &str = "wowm_language/src/spec/update-mask.md";
-    const LOOKUP_TABLE: &str = "## Lookup Table\n";
+    const LOOKUP_TABLE: &str = "## Lookup Table";
     let contents = read_to_string(UPDATE_MASK_FILE).unwrap();
 
     let update_types = [
@@ -123,7 +123,7 @@ pub fn print_update_mask() {
         if let UfType::BytesWithTypes(a, b, c, d) = m.ty() {
             s.wln(format!(
                 // The UpdateMask implementation realistically only works with 1.12
-                "use crate::vanilla::{{{}, {}, {}, {}}};",
+                "use crate::shared::{{{}, {}, {}, {}}};",
                 a, b, c, d
             ));
 

--- a/wow_message_parser/wowm/world/common.wowm
+++ b/wow_message_parser/wowm/world/common.wowm
@@ -1,4 +1,4 @@
-#tag_all versions "1.12";
+#tag_all versions "*";
 
 enum Power : u8 {
     MANA = 0 {

--- a/wow_message_parser/wowm/world/enums/class.wowm
+++ b/wow_message_parser/wowm/world/enums/class.wowm
@@ -1,4 +1,4 @@
-#tag_all versions "1.12";
+#tag_all versions "*";
 
 enum Class : u8 {
     WARRIOR = 1;
@@ -6,6 +6,7 @@ enum Class : u8 {
     HUNTER = 3;
     ROGUE = 4;
     PRIEST = 5;
+    DEATH_KNIGHT = 6;
     SHAMAN = 7;
     MAGE = 8;
     WARLOCK = 9;

--- a/wow_message_parser/wowm/world/enums/gender.wowm
+++ b/wow_message_parser/wowm/world/enums/gender.wowm
@@ -1,4 +1,4 @@
-#tag_all versions "1.12";
+#tag_all versions "*";
 
 enum Gender : u8 {
     MALE = 0;

--- a/wow_message_parser/wowm/world/enums/map.wowm
+++ b/wow_message_parser/wowm/world/enums/map.wowm
@@ -1,4 +1,5 @@
-#tag_all versions "1.12";
+#tag_all versions "*";
+
 enum Map : u32 {
     EASTERN_KINGDOMS = 0 {
         display = "Eastern Kingdoms";

--- a/wow_message_parser/wowm/world/enums/race.wowm
+++ b/wow_message_parser/wowm/world/enums/race.wowm
@@ -1,4 +1,4 @@
-#tag_all versions "1.12";
+#tag_all versions "*";
 
 enum Race : u8 {
     HUMAN = 1;
@@ -10,6 +10,7 @@ enum Race : u8 {
     GNOME = 7;
     TROLL = 8;
     GOBLIN = 9;
+    BLOOD_ELF = 10;
 } {
     rust_common_type = "true";
 }


### PR DESCRIPTION
This branch puts common things in a "shared" mod. It also enforces that anything that is marked as common (ending up in wow_world_base) is also marked for wildcard versions.

This lets us more easily share things that are definitely the same between versions.