### PR TITLE
Add decompressed_addon_size field to the CMSG_AUTH_SESSION (wrath)

### DIFF
--- a/wow_message_parser/wowm/world/character_screen/cmsg_auth_session.wowm
+++ b/wow_message_parser/wowm/world/character_screen/cmsg_auth_session.wowm
@@ -82,6 +82,7 @@ cmsg CMSG_AUTH_SESSION = 0x1ED {
         comment = "TrinityCore has this name but never uses the variable afterwards.";
     }
     u8[20] client_proof;
+    u32 decompressed_addon_info_size;
     u8[-] compressed_addon_info;
 } {
     versions = "3.3.5";


### PR DESCRIPTION
This field was missing. You can see me (succesfully) reading it [here](https://github.com/Victov/wrath-rs/blob/905ed472b9f1be65cdb0cf07dee2ce6821d3b65c/world_server/src/handlers/login_handler.rs#L66) right behind the 20-byte long digest, so this field definitely exists.