### PR TITLE
Fix files getting deleted on Windows because of platform-dependent slashes.

### DIFF
--- a/wow_message_parser/src/file_utils.rs
+++ b/wow_message_parser/src/file_utils.rs
@@ -94,7 +94,9 @@ impl ModFiles {
                     continue;
                 }
 
-                already_existing_files.insert(file.path().to_str().unwrap().to_string(), false);
+                use path_slash::PathExt as _;
+                let filename = file.path().to_slash().unwrap();
+                already_existing_files.insert(filename.into(), false);
             }
         }
 


### PR DESCRIPTION
On windows a lot of paths with backslashes would be added to the `already_existing_files` map with value `false`. During the run of the program they never get overridden because the program adds paths with forward slashes. Then, during `remove_unwritten_files`, all those backslash paths would happily get deleted.

This fixes the problem, at least on Windows, but there might be more problems lurking on other unknown operating systems. Perhaps a more robust solution is to store `PathBuf`s in the `already_existing_files` Map instead of `Strings`, since they are more platform independent. 