### PR TITLE
Add support for creating wow_messages::DateTime from a chrono::DateTime

### DIFF
--- a/wow_world_messages/Cargo.toml
+++ b/wow_world_messages/Cargo.toml
@@ -23,6 +23,10 @@ tbc = []
 wrath = []
 encryption = ["wow_srp"]
 
+[dependencies.chrono]
+version = "0.4"
+optional = true
+
 [dependencies.tokio]
 version = "1"
 default-features = false

--- a/wow_world_messages/src/helper/datetime.rs
+++ b/wow_world_messages/src/helper/datetime.rs
@@ -38,3 +38,37 @@ impl DateTime {
         self.inner
     }
 }
+
+#[cfg(feature = "chrono")]
+impl<T: chrono::prelude::TimeZone> std::convert::TryFrom<chrono::prelude::DateTime<T>>
+    for DateTime
+{
+    type Error = &'static str;
+
+    fn try_from(dt: chrono::prelude::DateTime<T>) -> Result<Self, Self::Error> {
+        use chrono::prelude::*;
+        use std::convert::TryInto;
+        let date_time = Self::new(
+            (dt.year() - 2000)
+                .try_into()
+                .map_err(|_| "Year does not fit in byte")?,
+            dt.month0()
+                .try_into()
+                .map_err(|_| "Month does not fit in byte")?,
+            dt.day0()
+                .try_into()
+                .map_err(|_| "Day does not fit in byte")?,
+            dt.weekday()
+                .num_days_from_monday()
+                .try_into()
+                .map_err(|_| "Day of week does not fit in byte")?,
+            dt.hour()
+                .try_into()
+                .map_err(|_| "Hour does not fit in byte")?,
+            dt.minute()
+                .try_into()
+                .map_err(|_| "Minute does fit in byte")?,
+        );
+        Ok(date_time)
+    }
+}


### PR DESCRIPTION
Feature is hidden behind optional feature flag. I think chrono is the de facto standard crate for time related things. This prevents consumers from having to go through extra steps to create a DateTime::now().

If it needs (small) changes before approval and you would rather just get them out of the way instead of waiting for me, go ahead, I don't feel any attachment to "my" contribution.