### PR TITLE
Add an assert against pre-nullterminated strings.

### DIFF
--- a/wow_login_messages/src/logon/version_2/realm.rs
+++ b/wow_login_messages/src/logon/version_2/realm.rs
@@ -39,15 +39,15 @@ impl Realm {
         w.write_all(&(self.flag.as_int() as u8).to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // address: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.address.as_bytes().iter().rev().next(), Some(&0u8), "String address must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.address.as_bytes().iter().rev().next(), Some(&0_u8), "String `address` must not be null-terminated.");
         w.write_all(self.address.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_login_messages/src/logon/version_2/realm.rs
+++ b/wow_login_messages/src/logon/version_2/realm.rs
@@ -39,11 +39,15 @@ impl Realm {
         w.write_all(&(self.flag.as_int() as u8).to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // address: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.address.as_bytes().iter().rev().next(), Some(&0u8), "String address must not be null-terminated.");
         w.write_all(self.address.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_login_messages/src/logon/version_8/realm.rs
+++ b/wow_login_messages/src/logon/version_8/realm.rs
@@ -50,15 +50,15 @@ impl Realm {
         w.write_all(&(self.flag.as_int() as u8).to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // address: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.address.as_bytes().iter().rev().next(), Some(&0u8), "String address must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.address.as_bytes().iter().rev().next(), Some(&0_u8), "String `address` must not be null-terminated.");
         w.write_all(self.address.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_login_messages/src/logon/version_8/realm.rs
+++ b/wow_login_messages/src/logon/version_8/realm.rs
@@ -50,11 +50,15 @@ impl Realm {
         w.write_all(&(self.flag.as_int() as u8).to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // address: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.address.as_bytes().iter().rev().next(), Some(&0u8), "String address must not be null-terminated.");
         w.write_all(self.address.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_message_parser/src/rust_printer/structs/print_common_impls/print_write.rs
+++ b/wow_message_parser/src/rust_printer/structs/print_common_impls/print_write.rs
@@ -188,6 +188,12 @@ pub fn print_write_definition(
             s.wln(format!("w.write_all(&[0]){postfix}?;", postfix = postfix,));
         }
         Type::CString => {
+            s.wln("// Guard against strings that are already null-terminated");
+            s.wln(format!(
+                "assert_ne!({prefix}{name}.as_bytes().iter().rev().next(), Some(&0u8), \"String {name} must not be null-terminated.\");", 
+                name = d.name(),
+                prefix = variable_prefix,
+            ));
             s.wln(format!(
                 "w.write_all({prefix}{name}.as_bytes()){postfix}?;",
                 name = d.name(),

--- a/wow_message_parser/src/rust_printer/structs/print_common_impls/print_write.rs
+++ b/wow_message_parser/src/rust_printer/structs/print_common_impls/print_write.rs
@@ -187,10 +187,11 @@ pub fn print_write_definition(
             s.wln("// Null terminator");
             s.wln(format!("w.write_all(&[0]){postfix}?;", postfix = postfix,));
         }
+        //TODO: types that prevent null bytes in strings
         Type::CString => {
-            s.wln("// Guard against strings that are already null-terminated");
+            s.wln("// TODO: Guard against strings that are already null-terminated");
             s.wln(format!(
-                "assert_ne!({prefix}{name}.as_bytes().iter().rev().next(), Some(&0u8), \"String {name} must not be null-terminated.\");", 
+                "assert_ne!({prefix}{name}.as_bytes().iter().rev().next(), Some(&0_u8), \"String `{name}` must not be null-terminated.\");", 
                 name = d.name(),
                 prefix = variable_prefix,
             ));

--- a/wow_message_parser/tests/cmsg_test_endless_u8.txt
+++ b/wow_message_parser/tests/cmsg_test_endless_u8.txt
@@ -25,6 +25,8 @@ impl crate::Message for CMSG_TEST_ENDLESS_U8 {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // c_string: CString
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.c_string.as_bytes().iter().rev().next(), Some(&0_u8), "String `c_string` must not be null-terminated.");
         w.write_all(self.c_string.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_message_parser/tests/cmsg_test_optional.txt
+++ b/wow_message_parser/tests/cmsg_test_optional.txt
@@ -27,6 +27,8 @@ impl crate::Message for CMSG_TEST_OPTIONAL {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // c_string: CString
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.c_string.as_bytes().iter().rev().next(), Some(&0_u8), "String `c_string` must not be null-terminated.");
         w.write_all(self.c_string.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_message_parser/tests/struct_with_all_built_in_types.txt
+++ b/wow_message_parser/tests/struct_with_all_built_in_types.txt
@@ -71,6 +71,8 @@ impl StructWithAllBuiltInTypes {
         w.write_all(&self.decimal64_be.to_be_bytes())?;
 
         // simple_cstring: CString
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.simple_cstring.as_bytes().iter().rev().next(), Some(&0_u8), "String `simple_cstring` must not be null-terminated.");
         w.write_all(self.simple_cstring.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/shared/cmsg_auth_session12.rs
+++ b/wow_world_messages/src/world/shared/cmsg_auth_session12.rs
@@ -45,6 +45,8 @@ impl crate::Message for CMSG_AUTH_SESSION {
         w.write_all(&self.server_id.to_le_bytes())?;
 
         // username: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.username.as_bytes().iter().rev().next(), Some(&0u8), "String username must not be null-terminated.");
         w.write_all(self.username.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/shared/cmsg_auth_session12.rs
+++ b/wow_world_messages/src/world/shared/cmsg_auth_session12.rs
@@ -45,8 +45,8 @@ impl crate::Message for CMSG_AUTH_SESSION {
         w.write_all(&self.server_id.to_le_bytes())?;
 
         // username: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.username.as_bytes().iter().rev().next(), Some(&0u8), "String username must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.username.as_bytes().iter().rev().next(), Some(&0_u8), "String `username` must not be null-terminated.");
         w.write_all(self.username.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/shared/cmsg_char_rename123.rs
+++ b/wow_world_messages/src/world/shared/cmsg_char_rename123.rs
@@ -29,8 +29,8 @@ impl crate::Message for CMSG_CHAR_RENAME {
         w.write_all(&self.character.guid().to_le_bytes())?;
 
         // new_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.new_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_name` must not be null-terminated.");
         w.write_all(self.new_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/shared/cmsg_char_rename123.rs
+++ b/wow_world_messages/src/world/shared/cmsg_char_rename123.rs
@@ -29,6 +29,8 @@ impl crate::Message for CMSG_CHAR_RENAME {
         w.write_all(&self.character.guid().to_le_bytes())?;
 
         // new_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
         w.write_all(self.new_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/shared/smsg_realm_split2_4_33.rs
+++ b/wow_world_messages/src/world/shared/smsg_realm_split2_4_33.rs
@@ -36,6 +36,8 @@ impl crate::Message for SMSG_REALM_SPLIT {
         w.write_all(&(self.state.as_int() as u32).to_le_bytes())?;
 
         // split_date: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.split_date.as_bytes().iter().rev().next(), Some(&0u8), "String split_date must not be null-terminated.");
         w.write_all(self.split_date.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/shared/smsg_realm_split2_4_33.rs
+++ b/wow_world_messages/src/world/shared/smsg_realm_split2_4_33.rs
@@ -36,8 +36,8 @@ impl crate::Message for SMSG_REALM_SPLIT {
         w.write_all(&(self.state.as_int() as u32).to_le_bytes())?;
 
         // split_date: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.split_date.as_bytes().iter().rev().next(), Some(&0u8), "String split_date must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.split_date.as_bytes().iter().rev().next(), Some(&0_u8), "String `split_date` must not be null-terminated.");
         w.write_all(self.split_date.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/tbc/character.rs
+++ b/wow_world_messages/src/world/tbc/character.rs
@@ -66,6 +66,8 @@ impl Character {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/tbc/character.rs
+++ b/wow_world_messages/src/world/tbc/character.rs
@@ -66,8 +66,8 @@ impl Character {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/tbc/cmsg_char_create.rs
+++ b/wow_world_messages/src/world/tbc/cmsg_char_create.rs
@@ -57,6 +57,8 @@ impl crate::Message for CMSG_CHAR_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/tbc/cmsg_char_create.rs
+++ b/wow_world_messages/src/world/tbc/cmsg_char_create.rs
@@ -57,8 +57,8 @@ impl crate::Message for CMSG_CHAR_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/tbc/smsg_char_rename.rs
+++ b/wow_world_messages/src/world/tbc/smsg_char_rename.rs
@@ -40,6 +40,8 @@ impl crate::Message for SMSG_CHAR_RENAME {
                 w.write_all(&character.guid().to_le_bytes())?;
 
                 // new_name: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
                 w.write_all(new_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/tbc/smsg_char_rename.rs
+++ b/wow_world_messages/src/world/tbc/smsg_char_rename.rs
@@ -40,8 +40,8 @@ impl crate::Message for SMSG_CHAR_RENAME {
                 w.write_all(&character.guid().to_le_bytes())?;
 
                 // new_name: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_name` must not be null-terminated.");
                 w.write_all(new_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/character.rs
+++ b/wow_world_messages/src/world/vanilla/character.rs
@@ -94,8 +94,8 @@ impl Character {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/character.rs
+++ b/wow_world_messages/src/world/vanilla/character.rs
@@ -94,6 +94,8 @@ impl Character {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_add_friend.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_add_friend.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_ADD_FRIEND {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // friend_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.friend_name.as_bytes().iter().rev().next(), Some(&0u8), "String friend_name must not be null-terminated.");
         w.write_all(self.friend_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_add_friend.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_add_friend.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_ADD_FRIEND {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // friend_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.friend_name.as_bytes().iter().rev().next(), Some(&0u8), "String friend_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.friend_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `friend_name` must not be null-terminated.");
         w.write_all(self.friend_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_add_ignore.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_add_ignore.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_ADD_IGNORE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // ignore_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.ignore_name.as_bytes().iter().rev().next(), Some(&0u8), "String ignore_name must not be null-terminated.");
         w.write_all(self.ignore_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_add_ignore.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_add_ignore.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_ADD_IGNORE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // ignore_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.ignore_name.as_bytes().iter().rev().next(), Some(&0u8), "String ignore_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.ignore_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `ignore_name` must not be null-terminated.");
         w.write_all(self.ignore_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_auction_list_items.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_auction_list_items.rs
@@ -46,6 +46,8 @@ impl crate::Message for CMSG_AUCTION_LIST_ITEMS {
         w.write_all(&self.list_start_item.to_le_bytes())?;
 
         // searched_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.searched_name.as_bytes().iter().rev().next(), Some(&0u8), "String searched_name must not be null-terminated.");
         w.write_all(self.searched_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_auction_list_items.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_auction_list_items.rs
@@ -46,8 +46,8 @@ impl crate::Message for CMSG_AUCTION_LIST_ITEMS {
         w.write_all(&self.list_start_item.to_le_bytes())?;
 
         // searched_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.searched_name.as_bytes().iter().rev().next(), Some(&0u8), "String searched_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.searched_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `searched_name` must not be null-terminated.");
         w.write_all(self.searched_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_announcements.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_announcements.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_CHANNEL_ANNOUNCEMENTS {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_announcements.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_announcements.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_CHANNEL_ANNOUNCEMENTS {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_ban.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_ban.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_BAN {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_ban.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_ban.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_BAN {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_invite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_invite.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_invite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_invite.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_kick.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_kick.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_KICK {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_kick.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_kick.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_KICK {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_list.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_list.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_CHANNEL_LIST {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_list.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_list.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_CHANNEL_LIST {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_moderate.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_moderate.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_CHANNEL_MODERATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_moderate.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_moderate.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_CHANNEL_MODERATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_moderator.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_moderator.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_MODERATOR {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_moderator.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_moderator.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_MODERATOR {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_mute.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_mute.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_MUTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_mute.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_mute.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_MUTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_owner.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_owner.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_CHANNEL_OWNER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_owner.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_owner.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_CHANNEL_OWNER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_password.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_password.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_PASSWORD {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // channel_password: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_password.as_bytes().iter().rev().next(), Some(&0u8), "String channel_password must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_password.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_password` must not be null-terminated.");
         w.write_all(self.channel_password.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_password.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_password.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_PASSWORD {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // channel_password: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_password.as_bytes().iter().rev().next(), Some(&0u8), "String channel_password must not be null-terminated.");
         w.write_all(self.channel_password.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_set_owner.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_set_owner.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_SET_OWNER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // new_owner: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.new_owner.as_bytes().iter().rev().next(), Some(&0u8), "String new_owner must not be null-terminated.");
         w.write_all(self.new_owner.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_set_owner.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_set_owner.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_SET_OWNER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // new_owner: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.new_owner.as_bytes().iter().rev().next(), Some(&0u8), "String new_owner must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.new_owner.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_owner` must not be null-terminated.");
         w.write_all(self.new_owner.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_unban.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_unban.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_UNBAN {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_unban.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_unban.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_UNBAN {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_unmoderator.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_unmoderator.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_UNMODERATOR {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_unmoderator.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_unmoderator.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_UNMODERATOR {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_unmute.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_unmute.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_CHANNEL_UNMUTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_channel_unmute.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_channel_unmute.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_CHANNEL_UNMUTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_char_create.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_char_create.rs
@@ -57,6 +57,8 @@ impl crate::Message for CMSG_CHAR_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_char_create.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_char_create.rs
@@ -57,8 +57,8 @@ impl crate::Message for CMSG_CHAR_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gmsurvey_submit.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gmsurvey_submit.rs
@@ -39,8 +39,8 @@ impl crate::Message for CMSG_GMSURVEY_SUBMIT {
         }
 
         // answer_comment: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.answer_comment.as_bytes().iter().rev().next(), Some(&0u8), "String answer_comment must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.answer_comment.as_bytes().iter().rev().next(), Some(&0_u8), "String `answer_comment` must not be null-terminated.");
         w.write_all(self.answer_comment.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gmsurvey_submit.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gmsurvey_submit.rs
@@ -39,6 +39,8 @@ impl crate::Message for CMSG_GMSURVEY_SUBMIT {
         }
 
         // answer_comment: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.answer_comment.as_bytes().iter().rev().next(), Some(&0u8), "String answer_comment must not be null-terminated.");
         w.write_all(self.answer_comment.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gmticket_create.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gmticket_create.rs
@@ -49,11 +49,15 @@ impl crate::Message for CMSG_GMTICKET_CREATE {
         self.position.write_into_vec(w)?;
 
         // message: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // reserved_for_future_use: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.reserved_for_future_use.as_bytes().iter().rev().next(), Some(&0u8), "String reserved_for_future_use must not be null-terminated.");
         w.write_all(self.reserved_for_future_use.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gmticket_create.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gmticket_create.rs
@@ -49,15 +49,15 @@ impl crate::Message for CMSG_GMTICKET_CREATE {
         self.position.write_into_vec(w)?;
 
         // message: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0_u8), "String `message` must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // reserved_for_future_use: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.reserved_for_future_use.as_bytes().iter().rev().next(), Some(&0u8), "String reserved_for_future_use must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.reserved_for_future_use.as_bytes().iter().rev().next(), Some(&0_u8), "String `reserved_for_future_use` must not be null-terminated.");
         w.write_all(self.reserved_for_future_use.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gmticket_updatetext.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gmticket_updatetext.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GMTICKET_UPDATETEXT {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // message: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0_u8), "String `message` must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gmticket_updatetext.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gmticket_updatetext.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GMTICKET_UPDATETEXT {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // message: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gossip_select_option.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gossip_select_option.rs
@@ -36,8 +36,8 @@ impl crate::Message for CMSG_GOSSIP_SELECT_OPTION {
         // optional unknown
         if let Some(v) = &self.unknown {
             // code: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.code.as_bytes().iter().rev().next(), Some(&0u8), "String code must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.code.as_bytes().iter().rev().next(), Some(&0_u8), "String `code` must not be null-terminated.");
             w.write_all(v.code.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_gossip_select_option.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_gossip_select_option.rs
@@ -36,6 +36,8 @@ impl crate::Message for CMSG_GOSSIP_SELECT_OPTION {
         // optional unknown
         if let Some(v) = &self.unknown {
             // code: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.code.as_bytes().iter().rev().next(), Some(&0u8), "String code must not be null-terminated.");
             w.write_all(v.code.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_change_sub_group.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_change_sub_group.rs
@@ -23,8 +23,8 @@ impl crate::Message for CMSG_GROUP_CHANGE_SUB_GROUP {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_change_sub_group.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_change_sub_group.rs
@@ -23,6 +23,8 @@ impl crate::Message for CMSG_GROUP_CHANGE_SUB_GROUP {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_invite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_invite.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GROUP_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_invite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_invite.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GROUP_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_swap_sub_group.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_swap_sub_group.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_GROUP_SWAP_SUB_GROUP {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // swap_with_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.swap_with_name.as_bytes().iter().rev().next(), Some(&0u8), "String swap_with_name must not be null-terminated.");
         w.write_all(self.swap_with_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_swap_sub_group.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_swap_sub_group.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_GROUP_SWAP_SUB_GROUP {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // swap_with_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.swap_with_name.as_bytes().iter().rev().next(), Some(&0u8), "String swap_with_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.swap_with_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `swap_with_name` must not be null-terminated.");
         w.write_all(self.swap_with_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_uninvite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_uninvite.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GROUP_UNINVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_group_uninvite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_group_uninvite.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GROUP_UNINVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_add_rank.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_add_rank.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_ADD_RANK {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // rank_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.rank_name.as_bytes().iter().rev().next(), Some(&0u8), "String rank_name must not be null-terminated.");
         w.write_all(self.rank_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_add_rank.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_add_rank.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_ADD_RANK {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // rank_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.rank_name.as_bytes().iter().rev().next(), Some(&0u8), "String rank_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.rank_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `rank_name` must not be null-terminated.");
         w.write_all(self.rank_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_create.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_create.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // guild_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_create.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_create.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // guild_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild_name` must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_demote.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_demote.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_DEMOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_demote.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_demote.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_DEMOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_info_text.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_info_text.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_INFO_TEXT {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // guild_info: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild_info.as_bytes().iter().rev().next(), Some(&0u8), "String guild_info must not be null-terminated.");
         w.write_all(self.guild_info.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_info_text.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_info_text.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_INFO_TEXT {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // guild_info: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild_info.as_bytes().iter().rev().next(), Some(&0u8), "String guild_info must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild_info.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild_info` must not be null-terminated.");
         w.write_all(self.guild_info.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_invite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_invite.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // invited_player: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.invited_player.as_bytes().iter().rev().next(), Some(&0u8), "String invited_player must not be null-terminated.");
         w.write_all(self.invited_player.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_invite.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_invite.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // invited_player: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.invited_player.as_bytes().iter().rev().next(), Some(&0u8), "String invited_player must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.invited_player.as_bytes().iter().rev().next(), Some(&0_u8), "String `invited_player` must not be null-terminated.");
         w.write_all(self.invited_player.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_leader.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_leader.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_LEADER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // new_guild_leader_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.new_guild_leader_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_guild_leader_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.new_guild_leader_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_guild_leader_name` must not be null-terminated.");
         w.write_all(self.new_guild_leader_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_leader.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_leader.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_LEADER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // new_guild_leader_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.new_guild_leader_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_guild_leader_name must not be null-terminated.");
         w.write_all(self.new_guild_leader_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_motd.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_motd.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_MOTD {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // message_of_the_day: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.message_of_the_day.as_bytes().iter().rev().next(), Some(&0u8), "String message_of_the_day must not be null-terminated.");
         w.write_all(self.message_of_the_day.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_motd.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_motd.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_MOTD {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // message_of_the_day: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.message_of_the_day.as_bytes().iter().rev().next(), Some(&0u8), "String message_of_the_day must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.message_of_the_day.as_bytes().iter().rev().next(), Some(&0_u8), "String `message_of_the_day` must not be null-terminated.");
         w.write_all(self.message_of_the_day.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_promote.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_promote.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_PROMOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_promote.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_promote.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_PROMOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_rank.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_rank.rs
@@ -31,6 +31,8 @@ impl crate::Message for CMSG_GUILD_RANK {
         w.write_all(&self.rights.to_le_bytes())?;
 
         // rank_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.rank_name.as_bytes().iter().rev().next(), Some(&0u8), "String rank_name must not be null-terminated.");
         w.write_all(self.rank_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_rank.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_rank.rs
@@ -31,8 +31,8 @@ impl crate::Message for CMSG_GUILD_RANK {
         w.write_all(&self.rights.to_le_bytes())?;
 
         // rank_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.rank_name.as_bytes().iter().rev().next(), Some(&0u8), "String rank_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.rank_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `rank_name` must not be null-terminated.");
         w.write_all(self.rank_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_remove.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_remove.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_GUILD_REMOVE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_remove.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_remove.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_GUILD_REMOVE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_set_officer_note.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_set_officer_note.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_GUILD_SET_OFFICER_NOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // note: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.note.as_bytes().iter().rev().next(), Some(&0u8), "String note must not be null-terminated.");
         w.write_all(self.note.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_set_officer_note.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_set_officer_note.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_GUILD_SET_OFFICER_NOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // note: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.note.as_bytes().iter().rev().next(), Some(&0u8), "String note must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.note.as_bytes().iter().rev().next(), Some(&0_u8), "String `note` must not be null-terminated.");
         w.write_all(self.note.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_set_public_note.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_set_public_note.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_GUILD_SET_PUBLIC_NOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // note: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.note.as_bytes().iter().rev().next(), Some(&0u8), "String note must not be null-terminated.");
         w.write_all(self.note.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_guild_set_public_note.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_guild_set_public_note.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_GUILD_SET_PUBLIC_NOTE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // note: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.note.as_bytes().iter().rev().next(), Some(&0u8), "String note must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.note.as_bytes().iter().rev().next(), Some(&0_u8), "String `note` must not be null-terminated.");
         w.write_all(self.note.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_join_channel.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_join_channel.rs
@@ -23,15 +23,15 @@ impl crate::Message for CMSG_JOIN_CHANNEL {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // channel_password: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_password.as_bytes().iter().rev().next(), Some(&0u8), "String channel_password must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_password.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_password` must not be null-terminated.");
         w.write_all(self.channel_password.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_join_channel.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_join_channel.rs
@@ -23,11 +23,15 @@ impl crate::Message for CMSG_JOIN_CHANNEL {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // channel_password: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_password.as_bytes().iter().rev().next(), Some(&0u8), "String channel_password must not be null-terminated.");
         w.write_all(self.channel_password.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_leave_channel.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_leave_channel.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_LEAVE_CHANNEL {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_leave_channel.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_leave_channel.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_LEAVE_CHANNEL {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_messagechat.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_messagechat.rs
@@ -49,8 +49,8 @@ impl crate::Message for CMSG_MESSAGECHAT {
                 target_player,
             } => {
                 // target_player: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(target_player.as_bytes().iter().rev().next(), Some(&0u8), "String target_player must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(target_player.as_bytes().iter().rev().next(), Some(&0_u8), "String `target_player` must not be null-terminated.");
                 w.write_all(target_player.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;
@@ -67,8 +67,8 @@ impl crate::Message for CMSG_MESSAGECHAT {
                 channel,
             } => {
                 // channel: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(channel.as_bytes().iter().rev().next(), Some(&0u8), "String channel must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(channel.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel` must not be null-terminated.");
                 w.write_all(channel.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;
@@ -97,8 +97,8 @@ impl crate::Message for CMSG_MESSAGECHAT {
         }
 
         // message: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0_u8), "String `message` must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_messagechat.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_messagechat.rs
@@ -49,6 +49,8 @@ impl crate::Message for CMSG_MESSAGECHAT {
                 target_player,
             } => {
                 // target_player: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(target_player.as_bytes().iter().rev().next(), Some(&0u8), "String target_player must not be null-terminated.");
                 w.write_all(target_player.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;
@@ -65,6 +67,8 @@ impl crate::Message for CMSG_MESSAGECHAT {
                 channel,
             } => {
                 // channel: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(channel.as_bytes().iter().rev().next(), Some(&0u8), "String channel must not be null-terminated.");
                 w.write_all(channel.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;
@@ -93,6 +97,8 @@ impl crate::Message for CMSG_MESSAGECHAT {
         }
 
         // message: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_pet_rename.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_pet_rename.rs
@@ -27,6 +27,8 @@ impl crate::Message for CMSG_PET_RENAME {
         w.write_all(&self.pet_guid.guid().to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_pet_rename.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_pet_rename.rs
@@ -27,8 +27,8 @@ impl crate::Message for CMSG_PET_RENAME {
         w.write_all(&self.pet_guid.guid().to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_petition_buy.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_petition_buy.rs
@@ -69,6 +69,8 @@ impl crate::Message for CMSG_PETITION_BUY {
         w.write_all(&self.skip2.guid().to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_petition_buy.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_petition_buy.rs
@@ -69,8 +69,8 @@ impl crate::Message for CMSG_PETITION_BUY {
         w.write_all(&self.skip2.guid().to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_send_mail.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_send_mail.rs
@@ -53,22 +53,22 @@ impl crate::Message for CMSG_SEND_MAIL {
         w.write_all(&self.mailbox.guid().to_le_bytes())?;
 
         // receiver: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.receiver.as_bytes().iter().rev().next(), Some(&0u8), "String receiver must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.receiver.as_bytes().iter().rev().next(), Some(&0_u8), "String `receiver` must not be null-terminated.");
         w.write_all(self.receiver.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // subject: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.subject.as_bytes().iter().rev().next(), Some(&0u8), "String subject must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.subject.as_bytes().iter().rev().next(), Some(&0_u8), "String `subject` must not be null-terminated.");
         w.write_all(self.subject.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // body: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.body.as_bytes().iter().rev().next(), Some(&0u8), "String body must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.body.as_bytes().iter().rev().next(), Some(&0_u8), "String `body` must not be null-terminated.");
         w.write_all(self.body.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_send_mail.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_send_mail.rs
@@ -53,16 +53,22 @@ impl crate::Message for CMSG_SEND_MAIL {
         w.write_all(&self.mailbox.guid().to_le_bytes())?;
 
         // receiver: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.receiver.as_bytes().iter().rev().next(), Some(&0u8), "String receiver must not be null-terminated.");
         w.write_all(self.receiver.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // subject: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.subject.as_bytes().iter().rev().next(), Some(&0u8), "String subject must not be null-terminated.");
         w.write_all(self.subject.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // body: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.body.as_bytes().iter().rev().next(), Some(&0u8), "String body must not be null-terminated.");
         w.write_all(self.body.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_teleport_to_unit.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_teleport_to_unit.rs
@@ -23,8 +23,8 @@ impl crate::Message for CMSG_TELEPORT_TO_UNIT {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_teleport_to_unit.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_teleport_to_unit.rs
@@ -23,6 +23,8 @@ impl crate::Message for CMSG_TELEPORT_TO_UNIT {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_who.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_who.rs
@@ -43,15 +43,15 @@ impl crate::Message for CMSG_WHO {
         w.write_all(&self.maximum_level.to_le_bytes())?;
 
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // guild_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild_name` must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_who.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_who.rs
@@ -43,11 +43,15 @@ impl crate::Message for CMSG_WHO {
         w.write_all(&self.maximum_level.to_le_bytes())?;
 
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // guild_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_whois.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_whois.rs
@@ -21,8 +21,8 @@ impl crate::Message for CMSG_WHOIS {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // character: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.character.as_bytes().iter().rev().next(), Some(&0u8), "String character must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.character.as_bytes().iter().rev().next(), Some(&0_u8), "String `character` must not be null-terminated.");
         w.write_all(self.character.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/cmsg_whois.rs
+++ b/wow_world_messages/src/world/vanilla/cmsg_whois.rs
@@ -21,6 +21,8 @@ impl crate::Message for CMSG_WHOIS {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // character: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.character.as_bytes().iter().rev().next(), Some(&0u8), "String character must not be null-terminated.");
         w.write_all(self.character.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/group_list_member.rs
+++ b/wow_world_messages/src/world/vanilla/group_list_member.rs
@@ -20,8 +20,8 @@ pub struct GroupListMember {
 impl GroupListMember {
     pub(crate) fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/group_list_member.rs
+++ b/wow_world_messages/src/world/vanilla/group_list_member.rs
@@ -20,6 +20,8 @@ pub struct GroupListMember {
 impl GroupListMember {
     pub(crate) fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/mail.rs
+++ b/wow_world_messages/src/world/vanilla/mail.rs
@@ -109,6 +109,8 @@ impl Mail {
         }
 
         // subject: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.subject.as_bytes().iter().rev().next(), Some(&0u8), "String subject must not be null-terminated.");
         w.write_all(self.subject.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/mail.rs
+++ b/wow_world_messages/src/world/vanilla/mail.rs
@@ -109,8 +109,8 @@ impl Mail {
         }
 
         // subject: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.subject.as_bytes().iter().rev().next(), Some(&0u8), "String subject must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.subject.as_bytes().iter().rev().next(), Some(&0_u8), "String `subject` must not be null-terminated.");
         w.write_all(self.subject.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/msg_petition_rename.rs
+++ b/wow_world_messages/src/world/vanilla/msg_petition_rename.rs
@@ -27,8 +27,8 @@ impl crate::Message for MSG_PETITION_RENAME {
         w.write_all(&self.petition_guid.guid().to_le_bytes())?;
 
         // new_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.new_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_name` must not be null-terminated.");
         w.write_all(self.new_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/msg_petition_rename.rs
+++ b/wow_world_messages/src/world/vanilla/msg_petition_rename.rs
@@ -27,6 +27,8 @@ impl crate::Message for MSG_PETITION_RENAME {
         w.write_all(&self.petition_guid.guid().to_le_bytes())?;
 
         // new_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
         w.write_all(self.new_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/quest_item.rs
+++ b/wow_world_messages/src/world/vanilla/quest_item.rs
@@ -32,6 +32,8 @@ impl QuestItem {
         w.write_all(&self.level.to_le_bytes())?;
 
         // title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/quest_item.rs
+++ b/wow_world_messages/src/world/vanilla/quest_item.rs
@@ -32,8 +32,8 @@ impl QuestItem {
         w.write_all(&self.level.to_le_bytes())?;
 
         // title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0_u8), "String `title` must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_channel_list.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_channel_list.rs
@@ -27,8 +27,8 @@ impl crate::Message for SMSG_CHANNEL_LIST {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_channel_list.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_channel_list.rs
@@ -27,6 +27,8 @@ impl crate::Message for SMSG_CHANNEL_LIST {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_channel_notify.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_channel_notify.rs
@@ -27,8 +27,8 @@ impl crate::Message for SMSG_CHANNEL_NOTIFY {
         w.write_all(&(self.notify_type.as_int() as u8).to_le_bytes())?;
 
         // channel_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_channel_notify.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_channel_notify.rs
@@ -27,6 +27,8 @@ impl crate::Message for SMSG_CHANNEL_NOTIFY {
         w.write_all(&(self.notify_type.as_int() as u8).to_le_bytes())?;
 
         // channel_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
         w.write_all(self.channel_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_char_rename.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_char_rename.rs
@@ -40,6 +40,8 @@ impl crate::Message for SMSG_CHAR_RENAME {
                 w.write_all(&character.guid().to_le_bytes())?;
 
                 // new_name: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
                 w.write_all(new_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_char_rename.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_char_rename.rs
@@ -40,8 +40,8 @@ impl crate::Message for SMSG_CHAR_RENAME {
                 w.write_all(&character.guid().to_le_bytes())?;
 
                 // new_name: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_name` must not be null-terminated.");
                 w.write_all(new_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_chat_player_not_found.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_chat_player_not_found.rs
@@ -21,6 +21,8 @@ impl crate::Message for SMSG_CHAT_PLAYER_NOT_FOUND {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_chat_player_not_found.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_chat_player_not_found.rs
@@ -21,8 +21,8 @@ impl crate::Message for SMSG_CHAT_PLAYER_NOT_FOUND {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_creature_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_creature_query_response.rs
@@ -43,36 +43,36 @@ impl crate::Message for SMSG_CREATURE_QUERY_RESPONSE {
         // optional found
         if let Some(v) = &self.found {
             // name1: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0u8), "String name1 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0_u8), "String `name1` must not be null-terminated.");
             w.write_all(v.name1.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name2: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0u8), "String name2 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0_u8), "String `name2` must not be null-terminated.");
             w.write_all(v.name2.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name3: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0u8), "String name3 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0_u8), "String `name3` must not be null-terminated.");
             w.write_all(v.name3.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name4: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0u8), "String name4 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0_u8), "String `name4` must not be null-terminated.");
             w.write_all(v.name4.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // sub_name: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.sub_name.as_bytes().iter().rev().next(), Some(&0u8), "String sub_name must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.sub_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `sub_name` must not be null-terminated.");
             w.write_all(v.sub_name.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_creature_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_creature_query_response.rs
@@ -43,26 +43,36 @@ impl crate::Message for SMSG_CREATURE_QUERY_RESPONSE {
         // optional found
         if let Some(v) = &self.found {
             // name1: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0u8), "String name1 must not be null-terminated.");
             w.write_all(v.name1.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name2: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0u8), "String name2 must not be null-terminated.");
             w.write_all(v.name2.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name3: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0u8), "String name3 must not be null-terminated.");
             w.write_all(v.name3.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name4: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0u8), "String name4 must not be null-terminated.");
             w.write_all(v.name4.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // sub_name: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.sub_name.as_bytes().iter().rev().next(), Some(&0u8), "String sub_name must not be null-terminated.");
             w.write_all(v.sub_name.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_duel_winner.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_duel_winner.rs
@@ -29,15 +29,15 @@ impl crate::Message for SMSG_DUEL_WINNER {
         w.write_all(&(self.reason.as_int() as u8).to_le_bytes())?;
 
         // opponent_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.opponent_name.as_bytes().iter().rev().next(), Some(&0u8), "String opponent_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.opponent_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `opponent_name` must not be null-terminated.");
         w.write_all(self.opponent_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // initiator_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.initiator_name.as_bytes().iter().rev().next(), Some(&0u8), "String initiator_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.initiator_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `initiator_name` must not be null-terminated.");
         w.write_all(self.initiator_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_duel_winner.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_duel_winner.rs
@@ -29,11 +29,15 @@ impl crate::Message for SMSG_DUEL_WINNER {
         w.write_all(&(self.reason.as_int() as u8).to_le_bytes())?;
 
         // opponent_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.opponent_name.as_bytes().iter().rev().next(), Some(&0u8), "String opponent_name must not be null-terminated.");
         w.write_all(self.opponent_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // initiator_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.initiator_name.as_bytes().iter().rev().next(), Some(&0u8), "String initiator_name must not be null-terminated.");
         w.write_all(self.initiator_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_gameobject_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_gameobject_query_response.rs
@@ -43,26 +43,36 @@ impl crate::Message for SMSG_GAMEOBJECT_QUERY_RESPONSE {
             w.write_all(&v.display_id.to_le_bytes())?;
 
             // name1: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0u8), "String name1 must not be null-terminated.");
             w.write_all(v.name1.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name2: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0u8), "String name2 must not be null-terminated.");
             w.write_all(v.name2.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name3: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0u8), "String name3 must not be null-terminated.");
             w.write_all(v.name3.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name4: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0u8), "String name4 must not be null-terminated.");
             w.write_all(v.name4.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name5: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name5.as_bytes().iter().rev().next(), Some(&0u8), "String name5 must not be null-terminated.");
             w.write_all(v.name5.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_gameobject_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_gameobject_query_response.rs
@@ -43,36 +43,36 @@ impl crate::Message for SMSG_GAMEOBJECT_QUERY_RESPONSE {
             w.write_all(&v.display_id.to_le_bytes())?;
 
             // name1: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0u8), "String name1 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0_u8), "String `name1` must not be null-terminated.");
             w.write_all(v.name1.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name2: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0u8), "String name2 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0_u8), "String `name2` must not be null-terminated.");
             w.write_all(v.name2.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name3: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0u8), "String name3 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0_u8), "String `name3` must not be null-terminated.");
             w.write_all(v.name3.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name4: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0u8), "String name4 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0_u8), "String `name4` must not be null-terminated.");
             w.write_all(v.name4.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name5: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name5.as_bytes().iter().rev().next(), Some(&0u8), "String name5 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name5.as_bytes().iter().rev().next(), Some(&0_u8), "String `name5` must not be null-terminated.");
             w.write_all(v.name5.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_gmticket_getticket.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_gmticket_getticket.rs
@@ -47,8 +47,8 @@ impl crate::Message for SMSG_GMTICKET_GETTICKET {
                 ticket_type,
             } => {
                 // text: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(text.as_bytes().iter().rev().next(), Some(&0u8), "String text must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(text.as_bytes().iter().rev().next(), Some(&0_u8), "String `text` must not be null-terminated.");
                 w.write_all(text.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_gmticket_getticket.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_gmticket_getticket.rs
@@ -47,6 +47,8 @@ impl crate::Message for SMSG_GMTICKET_GETTICKET {
                 ticket_type,
             } => {
                 // text: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(text.as_bytes().iter().rev().next(), Some(&0u8), "String text must not be null-terminated.");
                 w.write_all(text.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_gossip_poi.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_gossip_poi.rs
@@ -46,8 +46,8 @@ impl crate::Message for SMSG_GOSSIP_POI {
         w.write_all(&self.data.to_le_bytes())?;
 
         // location_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.location_name.as_bytes().iter().rev().next(), Some(&0u8), "String location_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.location_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `location_name` must not be null-terminated.");
         w.write_all(self.location_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_gossip_poi.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_gossip_poi.rs
@@ -46,6 +46,8 @@ impl crate::Message for SMSG_GOSSIP_POI {
         w.write_all(&self.data.to_le_bytes())?;
 
         // location_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.location_name.as_bytes().iter().rev().next(), Some(&0u8), "String location_name must not be null-terminated.");
         w.write_all(self.location_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_group_decline.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_group_decline.rs
@@ -21,6 +21,8 @@ impl crate::Message for SMSG_GROUP_DECLINE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_group_decline.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_group_decline.rs
@@ -21,8 +21,8 @@ impl crate::Message for SMSG_GROUP_DECLINE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_group_invite.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_group_invite.rs
@@ -21,8 +21,8 @@ impl crate::Message for SMSG_GROUP_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_group_invite.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_group_invite.rs
@@ -21,6 +21,8 @@ impl crate::Message for SMSG_GROUP_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_group_set_leader.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_group_set_leader.rs
@@ -21,8 +21,8 @@ impl crate::Message for SMSG_GROUP_SET_LEADER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_group_set_leader.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_group_set_leader.rs
@@ -21,6 +21,8 @@ impl crate::Message for SMSG_GROUP_SET_LEADER {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_command_result.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_command_result.rs
@@ -30,8 +30,8 @@ impl crate::Message for SMSG_GUILD_COMMAND_RESULT {
         w.write_all(&(self.command.as_int() as u32).to_le_bytes())?;
 
         // string: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.string.as_bytes().iter().rev().next(), Some(&0u8), "String string must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.string.as_bytes().iter().rev().next(), Some(&0_u8), "String `string` must not be null-terminated.");
         w.write_all(self.string.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_command_result.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_command_result.rs
@@ -30,6 +30,8 @@ impl crate::Message for SMSG_GUILD_COMMAND_RESULT {
         w.write_all(&(self.command.as_int() as u32).to_le_bytes())?;
 
         // string: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.string.as_bytes().iter().rev().next(), Some(&0u8), "String string must not be null-terminated.");
         w.write_all(self.string.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_info.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_info.rs
@@ -31,6 +31,8 @@ impl crate::Message for SMSG_GUILD_INFO {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // guild_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_info.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_info.rs
@@ -31,8 +31,8 @@ impl crate::Message for SMSG_GUILD_INFO {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // guild_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild_name` must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_invite.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_invite.rs
@@ -23,15 +23,15 @@ impl crate::Message for SMSG_GUILD_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `player_name` must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // guild_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild_name` must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_invite.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_invite.rs
@@ -23,11 +23,15 @@ impl crate::Message for SMSG_GUILD_INVITE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // player_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.player_name.as_bytes().iter().rev().next(), Some(&0u8), "String player_name must not be null-terminated.");
         w.write_all(self.player_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // guild_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_query_response.rs
@@ -38,6 +38,8 @@ impl crate::Message for SMSG_GUILD_QUERY_RESPONSE {
         w.write_all(&self.id.to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_guild_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_guild_query_response.rs
@@ -38,8 +38,8 @@ impl crate::Message for SMSG_GUILD_QUERY_RESPONSE {
         w.write_all(&self.id.to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_item_name_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_item_name_query_response.rs
@@ -26,8 +26,8 @@ impl crate::Message for SMSG_ITEM_NAME_QUERY_RESPONSE {
         w.write_all(&self.item_id.to_le_bytes())?;
 
         // item_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.item_name.as_bytes().iter().rev().next(), Some(&0u8), "String item_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.item_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `item_name` must not be null-terminated.");
         w.write_all(self.item_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_item_name_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_item_name_query_response.rs
@@ -26,6 +26,8 @@ impl crate::Message for SMSG_ITEM_NAME_QUERY_RESPONSE {
         w.write_all(&self.item_id.to_le_bytes())?;
 
         // item_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.item_name.as_bytes().iter().rev().next(), Some(&0u8), "String item_name must not be null-terminated.");
         w.write_all(self.item_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_item_query_single_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_item_query_single_response.rs
@@ -98,29 +98,29 @@ impl crate::Message for SMSG_ITEM_QUERY_SINGLE_RESPONSE {
             w.write_all(&v.item_sub_class.to_le_bytes())?;
 
             // name1: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0u8), "String name1 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0_u8), "String `name1` must not be null-terminated.");
             w.write_all(v.name1.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name2: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0u8), "String name2 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0_u8), "String `name2` must not be null-terminated.");
             w.write_all(v.name2.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name3: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0u8), "String name3 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0_u8), "String `name3` must not be null-terminated.");
             w.write_all(v.name3.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name4: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0u8), "String name4 must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0_u8), "String `name4` must not be null-terminated.");
             w.write_all(v.name4.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
@@ -234,8 +234,8 @@ impl crate::Message for SMSG_ITEM_QUERY_SINGLE_RESPONSE {
             w.write_all(&v.bonding.to_le_bytes())?;
 
             // description: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(v.description.as_bytes().iter().rev().next(), Some(&0u8), "String description must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(v.description.as_bytes().iter().rev().next(), Some(&0_u8), "String `description` must not be null-terminated.");
             w.write_all(v.description.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_item_query_single_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_item_query_single_response.rs
@@ -98,21 +98,29 @@ impl crate::Message for SMSG_ITEM_QUERY_SINGLE_RESPONSE {
             w.write_all(&v.item_sub_class.to_le_bytes())?;
 
             // name1: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name1.as_bytes().iter().rev().next(), Some(&0u8), "String name1 must not be null-terminated.");
             w.write_all(v.name1.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name2: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name2.as_bytes().iter().rev().next(), Some(&0u8), "String name2 must not be null-terminated.");
             w.write_all(v.name2.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name3: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name3.as_bytes().iter().rev().next(), Some(&0u8), "String name3 must not be null-terminated.");
             w.write_all(v.name3.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
 
             // name4: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.name4.as_bytes().iter().rev().next(), Some(&0u8), "String name4 must not be null-terminated.");
             w.write_all(v.name4.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;
@@ -226,6 +234,8 @@ impl crate::Message for SMSG_ITEM_QUERY_SINGLE_RESPONSE {
             w.write_all(&v.bonding.to_le_bytes())?;
 
             // description: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(v.description.as_bytes().iter().rev().next(), Some(&0u8), "String description must not be null-terminated.");
             w.write_all(v.description.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_item_text_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_item_text_query_response.rs
@@ -28,6 +28,8 @@ impl crate::Message for SMSG_ITEM_TEXT_QUERY_RESPONSE {
         w.write_all(&self.item_text_id.to_le_bytes())?;
 
         // text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.text.as_bytes().iter().rev().next(), Some(&0u8), "String text must not be null-terminated.");
         w.write_all(self.text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_item_text_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_item_text_query_response.rs
@@ -28,8 +28,8 @@ impl crate::Message for SMSG_ITEM_TEXT_QUERY_RESPONSE {
         w.write_all(&self.item_text_id.to_le_bytes())?;
 
         // text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.text.as_bytes().iter().rev().next(), Some(&0u8), "String text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.text.as_bytes().iter().rev().next(), Some(&0_u8), "String `text` must not be null-terminated.");
         w.write_all(self.text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_messagechat.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_messagechat.rs
@@ -208,6 +208,8 @@ impl crate::Message for SMSG_MESSAGECHAT {
                 player_rank,
             } => {
                 // channel_name: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
                 w.write_all(channel_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_messagechat.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_messagechat.rs
@@ -208,8 +208,8 @@ impl crate::Message for SMSG_MESSAGECHAT {
                 player_rank,
             } => {
                 // channel_name: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(channel_name.as_bytes().iter().rev().next(), Some(&0u8), "String channel_name must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(channel_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `channel_name` must not be null-terminated.");
                 w.write_all(channel_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_name_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_name_query_response.rs
@@ -42,11 +42,15 @@ impl crate::Message for SMSG_NAME_QUERY_RESPONSE {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // character_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.character_name.as_bytes().iter().rev().next(), Some(&0u8), "String character_name must not be null-terminated.");
         w.write_all(self.character_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // realm_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.realm_name.as_bytes().iter().rev().next(), Some(&0u8), "String realm_name must not be null-terminated.");
         w.write_all(self.realm_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_name_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_name_query_response.rs
@@ -42,15 +42,15 @@ impl crate::Message for SMSG_NAME_QUERY_RESPONSE {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // character_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.character_name.as_bytes().iter().rev().next(), Some(&0u8), "String character_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.character_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `character_name` must not be null-terminated.");
         w.write_all(self.character_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // realm_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.realm_name.as_bytes().iter().rev().next(), Some(&0u8), "String realm_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.realm_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `realm_name` must not be null-terminated.");
         w.write_all(self.realm_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_notification.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_notification.rs
@@ -21,8 +21,8 @@ impl crate::Message for SMSG_NOTIFICATION {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // notification: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.notification.as_bytes().iter().rev().next(), Some(&0u8), "String notification must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.notification.as_bytes().iter().rev().next(), Some(&0_u8), "String `notification` must not be null-terminated.");
         w.write_all(self.notification.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_notification.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_notification.rs
@@ -21,6 +21,8 @@ impl crate::Message for SMSG_NOTIFICATION {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // notification: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.notification.as_bytes().iter().rev().next(), Some(&0u8), "String notification must not be null-terminated.");
         w.write_all(self.notification.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_page_text_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_page_text_query_response.rs
@@ -28,8 +28,8 @@ impl crate::Message for SMSG_PAGE_TEXT_QUERY_RESPONSE {
         w.write_all(&self.page_id.to_le_bytes())?;
 
         // text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.text.as_bytes().iter().rev().next(), Some(&0u8), "String text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.text.as_bytes().iter().rev().next(), Some(&0_u8), "String `text` must not be null-terminated.");
         w.write_all(self.text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_page_text_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_page_text_query_response.rs
@@ -28,6 +28,8 @@ impl crate::Message for SMSG_PAGE_TEXT_QUERY_RESPONSE {
         w.write_all(&self.page_id.to_le_bytes())?;
 
         // text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.text.as_bytes().iter().rev().next(), Some(&0u8), "String text must not be null-terminated.");
         w.write_all(self.text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_party_command_result.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_party_command_result.rs
@@ -30,8 +30,8 @@ impl crate::Message for SMSG_PARTY_COMMAND_RESULT {
         w.write_all(&(self.operation.as_int() as u32).to_le_bytes())?;
 
         // member: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.member.as_bytes().iter().rev().next(), Some(&0u8), "String member must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.member.as_bytes().iter().rev().next(), Some(&0_u8), "String `member` must not be null-terminated.");
         w.write_all(self.member.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_party_command_result.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_party_command_result.rs
@@ -30,6 +30,8 @@ impl crate::Message for SMSG_PARTY_COMMAND_RESULT {
         w.write_all(&(self.operation.as_int() as u32).to_le_bytes())?;
 
         // member: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.member.as_bytes().iter().rev().next(), Some(&0u8), "String member must not be null-terminated.");
         w.write_all(self.member.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_party_member_stats.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_party_member_stats.rs
@@ -154,8 +154,8 @@ impl crate::Message for SMSG_PARTY_MEMBER_STATS {
 
         if let Some(if_statement) = &self.mask.flag_pet_name {
             // pet_name: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(if_statement.pet_name.as_bytes().iter().rev().next(), Some(&0u8), "String pet_name must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(if_statement.pet_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `pet_name` must not be null-terminated.");
             w.write_all(if_statement.pet_name.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_party_member_stats.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_party_member_stats.rs
@@ -154,6 +154,8 @@ impl crate::Message for SMSG_PARTY_MEMBER_STATS {
 
         if let Some(if_statement) = &self.mask.flag_pet_name {
             // pet_name: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(if_statement.pet_name.as_bytes().iter().rev().next(), Some(&0u8), "String pet_name must not be null-terminated.");
             w.write_all(if_statement.pet_name.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_party_member_stats_full.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_party_member_stats_full.rs
@@ -154,6 +154,8 @@ impl crate::Message for SMSG_PARTY_MEMBER_STATS_FULL {
 
         if let Some(if_statement) = &self.mask.flag_pet_name {
             // pet_name: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(if_statement.pet_name.as_bytes().iter().rev().next(), Some(&0u8), "String pet_name must not be null-terminated.");
             w.write_all(if_statement.pet_name.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_party_member_stats_full.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_party_member_stats_full.rs
@@ -154,8 +154,8 @@ impl crate::Message for SMSG_PARTY_MEMBER_STATS_FULL {
 
         if let Some(if_statement) = &self.mask.flag_pet_name {
             // pet_name: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(if_statement.pet_name.as_bytes().iter().rev().next(), Some(&0u8), "String pet_name must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(if_statement.pet_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `pet_name` must not be null-terminated.");
             w.write_all(if_statement.pet_name.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_pet_name_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_pet_name_query_response.rs
@@ -28,8 +28,8 @@ impl crate::Message for SMSG_PET_NAME_QUERY_RESPONSE {
         w.write_all(&self.pet_number.to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_pet_name_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_pet_name_query_response.rs
@@ -28,6 +28,8 @@ impl crate::Message for SMSG_PET_NAME_QUERY_RESPONSE {
         w.write_all(&self.pet_number.to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_petition_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_petition_query_response.rs
@@ -88,15 +88,15 @@ impl crate::Message for SMSG_PETITION_QUERY_RESPONSE {
         w.write_all(&self.charter_owner.guid().to_le_bytes())?;
 
         // guild_name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild_name` must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // body_text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.body_text.as_bytes().iter().rev().next(), Some(&0u8), "String body_text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.body_text.as_bytes().iter().rev().next(), Some(&0_u8), "String `body_text` must not be null-terminated.");
         w.write_all(self.body_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_petition_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_petition_query_response.rs
@@ -88,11 +88,15 @@ impl crate::Message for SMSG_PETITION_QUERY_RESPONSE {
         w.write_all(&self.charter_owner.guid().to_le_bytes())?;
 
         // guild_name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild_name.as_bytes().iter().rev().next(), Some(&0u8), "String guild_name must not be null-terminated.");
         w.write_all(self.guild_name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // body_text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.body_text.as_bytes().iter().rev().next(), Some(&0u8), "String body_text must not be null-terminated.");
         w.write_all(self.body_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_quest_confirm_accept.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_quest_confirm_accept.rs
@@ -29,8 +29,8 @@ impl crate::Message for SMSG_QUEST_CONFIRM_ACCEPT {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // quest_title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.quest_title.as_bytes().iter().rev().next(), Some(&0u8), "String quest_title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.quest_title.as_bytes().iter().rev().next(), Some(&0_u8), "String `quest_title` must not be null-terminated.");
         w.write_all(self.quest_title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_quest_confirm_accept.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_quest_confirm_accept.rs
@@ -29,6 +29,8 @@ impl crate::Message for SMSG_QUEST_CONFIRM_ACCEPT {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // quest_title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.quest_title.as_bytes().iter().rev().next(), Some(&0u8), "String quest_title must not be null-terminated.");
         w.write_all(self.quest_title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_quest_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_quest_query_response.rs
@@ -156,29 +156,29 @@ impl crate::Message for SMSG_QUEST_QUERY_RESPONSE {
         w.write_all(&self.point_opt.to_le_bytes())?;
 
         // title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0_u8), "String `title` must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // objective_text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.objective_text.as_bytes().iter().rev().next(), Some(&0u8), "String objective_text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.objective_text.as_bytes().iter().rev().next(), Some(&0_u8), "String `objective_text` must not be null-terminated.");
         w.write_all(self.objective_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // details: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.details.as_bytes().iter().rev().next(), Some(&0u8), "String details must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.details.as_bytes().iter().rev().next(), Some(&0_u8), "String `details` must not be null-terminated.");
         w.write_all(self.details.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // end_text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.end_text.as_bytes().iter().rev().next(), Some(&0u8), "String end_text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.end_text.as_bytes().iter().rev().next(), Some(&0_u8), "String `end_text` must not be null-terminated.");
         w.write_all(self.end_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_quest_query_response.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_quest_query_response.rs
@@ -156,21 +156,29 @@ impl crate::Message for SMSG_QUEST_QUERY_RESPONSE {
         w.write_all(&self.point_opt.to_le_bytes())?;
 
         // title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // objective_text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.objective_text.as_bytes().iter().rev().next(), Some(&0u8), "String objective_text must not be null-terminated.");
         w.write_all(self.objective_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // details: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.details.as_bytes().iter().rev().next(), Some(&0u8), "String details must not be null-terminated.");
         w.write_all(self.details.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // end_text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.end_text.as_bytes().iter().rev().next(), Some(&0u8), "String end_text must not be null-terminated.");
         w.write_all(self.end_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_offer_reward.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_offer_reward.rs
@@ -57,11 +57,15 @@ impl crate::Message for SMSG_QUESTGIVER_OFFER_REWARD {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // offer_reward_text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.offer_reward_text.as_bytes().iter().rev().next(), Some(&0u8), "String offer_reward_text must not be null-terminated.");
         w.write_all(self.offer_reward_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_offer_reward.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_offer_reward.rs
@@ -57,15 +57,15 @@ impl crate::Message for SMSG_QUESTGIVER_OFFER_REWARD {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0_u8), "String `title` must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // offer_reward_text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.offer_reward_text.as_bytes().iter().rev().next(), Some(&0u8), "String offer_reward_text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.offer_reward_text.as_bytes().iter().rev().next(), Some(&0_u8), "String `offer_reward_text` must not be null-terminated.");
         w.write_all(self.offer_reward_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_details.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_details.rs
@@ -55,22 +55,22 @@ impl crate::Message for SMSG_QUESTGIVER_QUEST_DETAILS {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0_u8), "String `title` must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // details: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.details.as_bytes().iter().rev().next(), Some(&0u8), "String details must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.details.as_bytes().iter().rev().next(), Some(&0_u8), "String `details` must not be null-terminated.");
         w.write_all(self.details.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // objectives: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.objectives.as_bytes().iter().rev().next(), Some(&0u8), "String objectives must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.objectives.as_bytes().iter().rev().next(), Some(&0_u8), "String `objectives` must not be null-terminated.");
         w.write_all(self.objectives.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_details.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_details.rs
@@ -55,16 +55,22 @@ impl crate::Message for SMSG_QUESTGIVER_QUEST_DETAILS {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // details: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.details.as_bytes().iter().rev().next(), Some(&0u8), "String details must not be null-terminated.");
         w.write_all(self.details.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // objectives: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.objectives.as_bytes().iter().rev().next(), Some(&0u8), "String objectives must not be null-terminated.");
         w.write_all(self.objectives.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_list.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_list.rs
@@ -39,8 +39,8 @@ impl crate::Message for SMSG_QUESTGIVER_QUEST_LIST {
         w.write_all(&self.npc.guid().to_le_bytes())?;
 
         // title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0_u8), "String `title` must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_list.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_quest_list.rs
@@ -39,6 +39,8 @@ impl crate::Message for SMSG_QUESTGIVER_QUEST_LIST {
         w.write_all(&self.npc.guid().to_le_bytes())?;
 
         // title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_request_items.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_request_items.rs
@@ -65,15 +65,15 @@ impl crate::Message for SMSG_QUESTGIVER_REQUEST_ITEMS {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // title: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0_u8), "String `title` must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // request_items_text: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.request_items_text.as_bytes().iter().rev().next(), Some(&0u8), "String request_items_text must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.request_items_text.as_bytes().iter().rev().next(), Some(&0_u8), "String `request_items_text` must not be null-terminated.");
         w.write_all(self.request_items_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_questgiver_request_items.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_questgiver_request_items.rs
@@ -65,11 +65,15 @@ impl crate::Message for SMSG_QUESTGIVER_REQUEST_ITEMS {
         w.write_all(&self.quest_id.to_le_bytes())?;
 
         // title: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.title.as_bytes().iter().rev().next(), Some(&0u8), "String title must not be null-terminated.");
         w.write_all(self.title.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // request_items_text: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.request_items_text.as_bytes().iter().rev().next(), Some(&0u8), "String request_items_text must not be null-terminated.");
         w.write_all(self.request_items_text.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_server_message.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_server_message.rs
@@ -27,6 +27,8 @@ impl crate::Message for SMSG_SERVER_MESSAGE {
         w.write_all(&(self.message_type.as_int() as u32).to_le_bytes())?;
 
         // message: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_server_message.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_server_message.rs
@@ -27,8 +27,8 @@ impl crate::Message for SMSG_SERVER_MESSAGE {
         w.write_all(&(self.message_type.as_int() as u32).to_le_bytes())?;
 
         // message: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0_u8), "String `message` must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_trainer_list.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_trainer_list.rs
@@ -44,6 +44,8 @@ impl crate::Message for SMSG_TRAINER_LIST {
         }
 
         // greeting: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.greeting.as_bytes().iter().rev().next(), Some(&0u8), "String greeting must not be null-terminated.");
         w.write_all(self.greeting.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_trainer_list.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_trainer_list.rs
@@ -44,8 +44,8 @@ impl crate::Message for SMSG_TRAINER_LIST {
         }
 
         // greeting: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.greeting.as_bytes().iter().rev().next(), Some(&0u8), "String greeting must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.greeting.as_bytes().iter().rev().next(), Some(&0_u8), "String `greeting` must not be null-terminated.");
         w.write_all(self.greeting.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_whois.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_whois.rs
@@ -21,8 +21,8 @@ impl crate::Message for SMSG_WHOIS {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // message: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0_u8), "String `message` must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/smsg_whois.rs
+++ b/wow_world_messages/src/world/vanilla/smsg_whois.rs
@@ -21,6 +21,8 @@ impl crate::Message for SMSG_WHOIS {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // message: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.message.as_bytes().iter().rev().next(), Some(&0u8), "String message must not be null-terminated.");
         w.write_all(self.message.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/spell_cast_targets.rs
+++ b/wow_world_messages/src/world/vanilla/spell_cast_targets.rs
@@ -118,6 +118,8 @@ impl SpellCastTargets {
 
         if let Some(if_statement) = &self.target_flags.string {
             // target_string: CString
+            // Guard against strings that are already null-terminated
+            assert_ne!(if_statement.target_string.as_bytes().iter().rev().next(), Some(&0u8), "String target_string must not be null-terminated.");
             w.write_all(if_statement.target_string.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/spell_cast_targets.rs
+++ b/wow_world_messages/src/world/vanilla/spell_cast_targets.rs
@@ -118,8 +118,8 @@ impl SpellCastTargets {
 
         if let Some(if_statement) = &self.target_flags.string {
             // target_string: CString
-            // Guard against strings that are already null-terminated
-            assert_ne!(if_statement.target_string.as_bytes().iter().rev().next(), Some(&0u8), "String target_string must not be null-terminated.");
+            // TODO: Guard against strings that are already null-terminated
+            assert_ne!(if_statement.target_string.as_bytes().iter().rev().next(), Some(&0_u8), "String `target_string` must not be null-terminated.");
             w.write_all(if_statement.target_string.as_bytes())?;
             // Null terminator
             w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/stabled_pet.rs
+++ b/wow_world_messages/src/world/vanilla/stabled_pet.rs
@@ -36,6 +36,8 @@ impl StabledPet {
         w.write_all(&self.level.to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/stabled_pet.rs
+++ b/wow_world_messages/src/world/vanilla/stabled_pet.rs
@@ -36,8 +36,8 @@ impl StabledPet {
         w.write_all(&self.level.to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/who_player.rs
+++ b/wow_world_messages/src/world/vanilla/who_player.rs
@@ -29,11 +29,15 @@ pub struct WhoPlayer {
 impl WhoPlayer {
     pub(crate) fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // guild: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.guild.as_bytes().iter().rev().next(), Some(&0u8), "String guild must not be null-terminated.");
         w.write_all(self.guild.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/vanilla/who_player.rs
+++ b/wow_world_messages/src/world/vanilla/who_player.rs
@@ -29,15 +29,15 @@ pub struct WhoPlayer {
 impl WhoPlayer {
     pub(crate) fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;
 
         // guild: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.guild.as_bytes().iter().rev().next(), Some(&0u8), "String guild must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.guild.as_bytes().iter().rev().next(), Some(&0_u8), "String `guild` must not be null-terminated.");
         w.write_all(self.guild.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/character.rs
+++ b/wow_world_messages/src/world/wrath/character.rs
@@ -68,8 +68,8 @@ impl Character {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/character.rs
+++ b/wow_world_messages/src/world/wrath/character.rs
@@ -68,6 +68,8 @@ impl Character {
         w.write_all(&self.guid.guid().to_le_bytes())?;
 
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/cmsg_auth_session.rs
+++ b/wow_world_messages/src/world/wrath/cmsg_auth_session.rs
@@ -56,8 +56,8 @@ impl crate::Message for CMSG_AUTH_SESSION {
         w.write_all(&self.login_server_id.to_le_bytes())?;
 
         // username: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.username.as_bytes().iter().rev().next(), Some(&0u8), "String username must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.username.as_bytes().iter().rev().next(), Some(&0_u8), "String `username` must not be null-terminated.");
         w.write_all(self.username.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/cmsg_auth_session.rs
+++ b/wow_world_messages/src/world/wrath/cmsg_auth_session.rs
@@ -56,6 +56,8 @@ impl crate::Message for CMSG_AUTH_SESSION {
         w.write_all(&self.login_server_id.to_le_bytes())?;
 
         // username: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.username.as_bytes().iter().rev().next(), Some(&0u8), "String username must not be null-terminated.");
         w.write_all(self.username.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/cmsg_char_create.rs
+++ b/wow_world_messages/src/world/wrath/cmsg_char_create.rs
@@ -57,6 +57,8 @@ impl crate::Message for CMSG_CHAR_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/cmsg_char_create.rs
+++ b/wow_world_messages/src/world/wrath/cmsg_char_create.rs
@@ -57,8 +57,8 @@ impl crate::Message for CMSG_CHAR_CREATE {
 
     fn write_into_vec(&self, w: &mut Vec<u8>) -> Result<(), std::io::Error> {
         // name: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0u8), "String name must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.name.as_bytes().iter().rev().next(), Some(&0_u8), "String `name` must not be null-terminated.");
         w.write_all(self.name.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/cmsg_set_active_voice_channel.rs
+++ b/wow_world_messages/src/world/wrath/cmsg_set_active_voice_channel.rs
@@ -26,6 +26,8 @@ impl crate::Message for CMSG_SET_ACTIVE_VOICE_CHANNEL {
         w.write_all(&self.unknown1.to_le_bytes())?;
 
         // unknown2: CString
+        // Guard against strings that are already null-terminated
+        assert_ne!(self.unknown2.as_bytes().iter().rev().next(), Some(&0u8), "String unknown2 must not be null-terminated.");
         w.write_all(self.unknown2.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/cmsg_set_active_voice_channel.rs
+++ b/wow_world_messages/src/world/wrath/cmsg_set_active_voice_channel.rs
@@ -26,8 +26,8 @@ impl crate::Message for CMSG_SET_ACTIVE_VOICE_CHANNEL {
         w.write_all(&self.unknown1.to_le_bytes())?;
 
         // unknown2: CString
-        // Guard against strings that are already null-terminated
-        assert_ne!(self.unknown2.as_bytes().iter().rev().next(), Some(&0u8), "String unknown2 must not be null-terminated.");
+        // TODO: Guard against strings that are already null-terminated
+        assert_ne!(self.unknown2.as_bytes().iter().rev().next(), Some(&0_u8), "String `unknown2` must not be null-terminated.");
         w.write_all(self.unknown2.as_bytes())?;
         // Null terminator
         w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/smsg_char_rename.rs
+++ b/wow_world_messages/src/world/wrath/smsg_char_rename.rs
@@ -40,6 +40,8 @@ impl crate::Message for SMSG_CHAR_RENAME {
                 w.write_all(&character.guid().to_le_bytes())?;
 
                 // new_name: CString
+                // Guard against strings that are already null-terminated
+                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
                 w.write_all(new_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;

--- a/wow_world_messages/src/world/wrath/smsg_char_rename.rs
+++ b/wow_world_messages/src/world/wrath/smsg_char_rename.rs
@@ -40,8 +40,8 @@ impl crate::Message for SMSG_CHAR_RENAME {
                 w.write_all(&character.guid().to_le_bytes())?;
 
                 // new_name: CString
-                // Guard against strings that are already null-terminated
-                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0u8), "String new_name must not be null-terminated.");
+                // TODO: Guard against strings that are already null-terminated
+                assert_ne!(new_name.as_bytes().iter().rev().next(), Some(&0_u8), "String `new_name` must not be null-terminated.");
                 w.write_all(new_name.as_bytes())?;
                 // Null terminator
                 w.write_all(&[0])?;


### PR DESCRIPTION
If strings are already null-terminated that can create some very nasty and hard to track bugs. It can be a real hidden problem that causes the message to be incorrect. Guard this sneaky scenario with an assert.