### PR TITLE
Split out the header and the dirty bookkeeping of the UpdateMask

### DIFF
--- a/wow_world_messages/src/helper/vanilla/update_mask/mod.rs
+++ b/wow_world_messages/src/helper/vanilla/update_mask/mod.rs
@@ -172,7 +172,7 @@ mod test {
             .set_unit_DISPLAYID(50)
             .set_unit_NATIVEDISPLAYID(50)
             .finalize();
-        update_mask.header_reset();
+        update_mask.dirty_reset();
 
         update_mask.set_object_GUID(4.into());
 
@@ -206,7 +206,7 @@ mod test {
             .set_unit_NATIVEDISPLAYID(50)
             .finalize();
 
-        update_mask.header_reset();
+        update_mask.dirty_reset();
         let update_mask = UpdateMask::Player(update_mask);
 
         let mut v = Vec::with_capacity(update_mask.size());
@@ -252,6 +252,57 @@ mod test {
 
         let mut v = Vec::with_capacity(update_mask.size());
         update_mask.write_into_vec(&mut v).unwrap();
+        assert_eq!(b.as_slice(), v.as_slice());
+    }
+
+    #[test]
+    fn reset_dirty_and_mark_full_dirty() {
+        let b = [
+            5_u8, // Amount of u32 mask blocks that will follow
+            // Mask blocks
+            23, 0, 64, 16, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0,
+            // End of mask blocks
+            4, 0, 0, 0, 0, 0, 0, 0, // OBJECT_FIELD_GUID (4) (notice unpacked u64)
+            25, 0, 0,
+            0, // OBJECT_FIELD_TYPE (16 | 8 | 1) (TYPE_PLAYER | TYPE_UNIT | TYPE_OBJECT)
+            0, 0, 128, 63, // Scale (1.0)
+            100, 0, 0, 0, // UNIT_FIELD_HEALTH (100)
+            100, 0, 0, 0, // UNIT_FIELD_MAXHEALTH (100)
+            1, 0, 0, 0, // UNIT_FIELD_LEVEL (1)
+            1, 0, 0, 0, // UNIT_FIELD_FACTIONTEMPLATE (1)
+            1, // UNIT_FIELD_BYTES[0] // Race (Human)
+            1, // UNIT_FIELD_BYTES[1] // Class (Warrior)
+            1, // UNIT_FIELD_BYTES[2] // Gender (Female)
+            1, // UNIT_FIELD_BYTES[3] // Power (Rage)
+            50, 0, 0, 0, // UNIT_FIELD_DISPLAYD (50, Human Female)
+            50, 0, 0, 0, // UNIT_FIELD_NATIVEDISPLAYID (50, Human Female)
+        ];
+
+        let mut update_mask = UpdatePlayer::builder()
+            .set_object_GUID(Guid::new(4))
+            .set_unit_BYTES_0(Race::Human, Class::Warrior, Gender::Female, Power::Rage)
+            .set_object_SCALE_X(1.0)
+            .set_unit_HEALTH(100)
+            .set_unit_MAXHEALTH(100)
+            .set_unit_LEVEL(1)
+            .set_unit_FACTIONTEMPLATE(1)
+            .set_unit_DISPLAYID(50)
+            .set_unit_NATIVEDISPLAYID(50)
+            .finalize();
+        //Fully clear the dirty mask
+        update_mask.dirty_reset();
+        assert!(!update_mask.has_any_dirty_fields());
+
+        //Mark completely dirty
+        update_mask.mark_fully_dirty();
+        assert!(update_mask.has_any_dirty_fields());
+
+        let update_mask = UpdateMask::Player(update_mask);
+
+        let mut v = Vec::with_capacity(update_mask.size());
+        update_mask.write_into_vec(&mut v).unwrap();
+
+        //Output should match all previously written fields
         assert_eq!(b.as_slice(), v.as_slice());
     }
 }


### PR DESCRIPTION
* Leave header of UpdateMask pure and clean
* Do bookkeeping of what is dirty in separate array
* Add function to mark the entire UpdateMask dirty at once ([used](https://github.com/Victov/wrath-rs/blob/27c923cc2297aef030f5545614c303d095329cb2/world_server/src/world/update_builder.rs#L51) for the purpose of sending Create blocks)
* Added test to verify new dirty bookkeeping behaviour