### PR TITLE
Format unknown opcode numbers as hex

### DIFF
--- a/wow_login_messages/src/errors.rs
+++ b/wow_login_messages/src/errors.rs
@@ -69,7 +69,9 @@ pub enum ExpectedOpcodeError {
 impl Display for ExpectedOpcodeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Opcode(opcode) => f.write_str(&format!("unexpected opcode found: '{}'", opcode)),
+            Self::Opcode(opcode) => {
+                f.write_str(&format!("unexpected opcode found: '{:#06X}'", opcode))
+            }
             Self::Parse(i) => i.fmt(f),
         }
     }

--- a/wow_world_messages/src/errors.rs
+++ b/wow_world_messages/src/errors.rs
@@ -53,7 +53,7 @@ impl Display for ExpectedOpcodeError {
         match self {
             Self::Opcode { opcode, size } => write!(
                 f,
-                "unexpected opcode found: '{}' and size '{}'",
+                "unexpected opcode found: '{:#06X}' and size '{}'",
                 opcode, size
             ),
             Self::Parse(i) => i.fmt(f),


### PR DESCRIPTION
Small tweak to print unknown opcodes as hex, so that looking up reference materials is easier.