### PR TITLE
Adjust value of unit_BYTES_1 to use the correct enum

### DIFF
--- a/wow_message_parser/src/rust_printer/update_mask/wrath_fields.rs
+++ b/wow_message_parser/src/rust_printer/update_mask/wrath_fields.rs
@@ -370,7 +370,18 @@ pub(crate) const FIELDS: [MemberType; 367] = [
         1,
         UfType::Float,
     ),
-    MemberType::new(UpdateMaskType::Unit, "BYTES_1", 0x004a, 1, UfType::Bytes),
+    MemberType::new(
+        UpdateMaskType::Unit,
+        "BYTES_1",
+        0x004a,
+        1,
+        UfType::BytesWith(
+            ByteType::new("stand_state", "UnitStandState"),
+            ByteType::byte("unknown1"),
+            ByteType::byte("unknown2"),
+            ByteType::byte("unknown3"),
+        ),
+    ),
     MemberType::new(UpdateMaskType::Unit, "PETNUMBER", 0x004b, 1, UfType::Int),
     MemberType::new(
         UpdateMaskType::Unit,

--- a/wow_world_messages/src/helper/wrath/update_mask/impls.rs
+++ b/wow_world_messages/src/helper/wrath/update_mask/impls.rs
@@ -4,6 +4,7 @@ use crate::wrath::{Race};
 use crate::wrath::{Class};
 use crate::wrath::{Gender};
 use crate::wrath::{Power};
+use crate::wrath::{UnitStandState};
 use crate::wrath::{UpdateContainer, UpdateContainerBuilder, UpdateCorpse, UpdateCorpseBuilder, UpdateDynamicObject, UpdateDynamicObjectBuilder, UpdateGameObject, UpdateGameObjectBuilder, UpdateItem, UpdateItemBuilder, UpdatePlayer, UpdatePlayerBuilder, UpdateUnit, UpdateUnitBuilder};
 
 impl UpdateItemBuilder {
@@ -867,9 +868,9 @@ impl UpdateUnitBuilder {
         self
     }
 
-    pub fn set_unit_BYTES_1(mut self, a: u8, b: u8, c: u8, d: u8) -> Self {
+    pub fn set_unit_BYTES_1(mut self, stand_state: UnitStandState, unknown1: u8, unknown2: u8, unknown3: u8) -> Self {
         self.header_set(74);
-        self.values.insert(74, u32::from_le_bytes([a, b, c, d]));
+        self.values.insert(74, u32::from_le_bytes([stand_state.as_int(), unknown1, unknown2, unknown3]));
         self
     }
 
@@ -1448,9 +1449,9 @@ impl UpdatePlayerBuilder {
         self
     }
 
-    pub fn set_unit_BYTES_1(mut self, a: u8, b: u8, c: u8, d: u8) -> Self {
+    pub fn set_unit_BYTES_1(mut self, stand_state: UnitStandState, unknown1: u8, unknown2: u8, unknown3: u8) -> Self {
         self.header_set(74);
-        self.values.insert(74, u32::from_le_bytes([a, b, c, d]));
+        self.values.insert(74, u32::from_le_bytes([stand_state.as_int(), unknown1, unknown2, unknown3]));
         self
     }
 
@@ -4751,16 +4752,16 @@ impl UpdateUnit {
         self.values.get(&73).map(|v| f32::from_le_bytes(v.to_le_bytes()))
     }
 
-    pub fn set_unit_BYTES_1(&mut self, a: u8, b: u8, c: u8, d: u8) {
+    pub fn set_unit_BYTES_1(&mut self, stand_state: UnitStandState, unknown1: u8, unknown2: u8, unknown3: u8) {
         self.header_set(74);
-        self.values.insert(74, u32::from_le_bytes([a, b, c, d]));
+        self.values.insert(74, u32::from_le_bytes([stand_state.as_int(), unknown1, unknown2, unknown3]));
     }
 
-    pub fn unit_BYTES_1(&self) -> Option<(u8, u8, u8, u8)> {
+    pub fn unit_BYTES_1(&self) -> Option<(UnitStandState, u8, u8, u8)> {
         if let Some(v) = self.values.get(&74) {
             let v = v.to_le_bytes();
-            let (a, b, c, d) = (v[0], v[1], v[2], v[3]);
-            Some((a, b, c, d))
+            let (stand_state, unknown1, unknown2, unknown3) = (v[0], v[1], v[2], v[3]);
+            Some((stand_state.try_into().unwrap(), unknown1, unknown2, unknown3))
         } else {
             None
         }
@@ -5671,16 +5672,16 @@ impl UpdatePlayer {
         self.values.get(&73).map(|v| f32::from_le_bytes(v.to_le_bytes()))
     }
 
-    pub fn set_unit_BYTES_1(&mut self, a: u8, b: u8, c: u8, d: u8) {
+    pub fn set_unit_BYTES_1(&mut self, stand_state: UnitStandState, unknown1: u8, unknown2: u8, unknown3: u8) {
         self.header_set(74);
-        self.values.insert(74, u32::from_le_bytes([a, b, c, d]));
+        self.values.insert(74, u32::from_le_bytes([stand_state.as_int(), unknown1, unknown2, unknown3]));
     }
 
-    pub fn unit_BYTES_1(&self) -> Option<(u8, u8, u8, u8)> {
+    pub fn unit_BYTES_1(&self) -> Option<(UnitStandState, u8, u8, u8)> {
         if let Some(v) = self.values.get(&74) {
             let v = v.to_le_bytes();
-            let (a, b, c, d) = (v[0], v[1], v[2], v[3]);
-            Some((a, b, c, d))
+            let (stand_state, unknown1, unknown2, unknown3) = (v[0], v[1], v[2], v[3]);
+            Some((stand_state.try_into().unwrap(), unknown1, unknown2, unknown3))
         } else {
             None
         }


### PR DESCRIPTION
There was an enum available to to model unit_BYTES_1 so I figured let's use that for increased type safety