### PR TITLE
Pass dirty mask to update data setters

### DIFF
--- a/wow_world_messages/src/helper/update_mask_common/mod.rs
+++ b/wow_world_messages/src/helper/update_mask_common/mod.rs
@@ -159,7 +159,7 @@ macro_rules! update_item {
                 $crate::helper::update_mask_common::inners::set_int(
                     &mut self.values,
                     &mut self.header,
-                    None,
+                    Some(&mut self.dirty_mask),
                     bit,
                     v,
                 );
@@ -175,7 +175,7 @@ macro_rules! update_item {
                 $crate::helper::update_mask_common::inners::set_float(
                     &mut self.values,
                     &mut self.header,
-                    None,
+                    Some(&mut self.dirty_mask),
                     bit,
                     v,
                 );
@@ -191,7 +191,7 @@ macro_rules! update_item {
                 $crate::helper::update_mask_common::inners::set_bytes(
                     &mut self.values,
                     &mut self.header,
-                    None,
+                    Some(&mut self.dirty_mask),
                     bit,
                     a,
                     b,
@@ -210,7 +210,7 @@ macro_rules! update_item {
                 $crate::helper::update_mask_common::inners::set_shorts(
                     &mut self.values,
                     &mut self.header,
-                    None,
+                    Some(&mut self.dirty_mask),
                     bit,
                     a,
                     b,

--- a/wow_world_messages/src/helper/vanilla/update_mask/mod.rs
+++ b/wow_world_messages/src/helper/vanilla/update_mask/mod.rs
@@ -339,4 +339,17 @@ mod test {
         //Output should match all previously written fields
         assert_eq!(b.as_slice(), v.as_slice());
     }
+    #[test]
+    fn update_mask_header_and_dirty_size()
+    {
+        //create update mask so header and mask  have size 1
+         let mut update_mask = UpdatePlayer::builder()
+            .set_object_guid(Guid::new(3))
+            .finalize();
+        //set a field that would need to increase the size of the header and dirty mask
+        update_mask.set_unit_displayid(49);
+        //check that the header and dirty mask are the same size
+        assert_eq!(update_mask.dirty_mask.len(),update_mask.header.len());
+    }
+
 }


### PR DESCRIPTION
Shouldn't these functions also pass the dirty mask? 
I get an assert failure in wrath-rs trying to update wow_messages without passing them, something about the mask size being different from the header size.