### PR TITLE
fix: correct base offset of field_inv

### DIFF
--- a/wow_message_parser/src/rust_printer/update_mask/wrath_fields.rs
+++ b/wow_message_parser/src/rust_printer/update_mask/wrath_fields.rs
@@ -1300,7 +1300,7 @@ pub(crate) const FIELDS: &[MemberType] = &[
     MemberType::new(
         UpdateMaskType::Player,
         "FIELD_INV",
-        0x1E6,
+        0x0144,
         300,
         UfType::GuidEnumLookupArray {
             name: "ItemSlot",

--- a/wow_world_messages/src/helper/wrath/update_mask/impls.rs
+++ b/wow_world_messages/src/helper/wrath/update_mask/impls.rs
@@ -5515,12 +5515,12 @@ impl UpdatePlayer {
     }
 
     pub fn set_player_field_inv(&mut self, item_slot: crate::wrath::ItemSlot, item: Guid) {
-        let offset = 486 + item_slot.as_int() as u16 * 2;
+        let offset = 324 + item_slot.as_int() as u16 * 2;
         self.set_guid(offset, item);
     }
 
     pub fn player_field_inv(&self, item_slot: crate::wrath::ItemSlot) -> Option<Guid> {
-        let offset = 486 + item_slot.as_int() as u16 * 2;
+        let offset = 324 + item_slot.as_int() as u16 * 2;
         self.get_guid(offset)
     }
 


### PR DESCRIPTION
The correct offset here seems to be 324, following set_player_fake_inebriation.
Found it from AC:

![image](https://github.com/gtker/wow_messages/assets/19265585/7ed4cc0d-1f69-4bce-8ae0-dfa797c410a8)

